### PR TITLE
GO-13710 Action sheet height is passed as a prop

### DIFF
--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -153,13 +153,14 @@ class ActionSheet extends Component {
     firstOptionButtonStyle,
     lastOptionButtonStyle,
     optionStyle,
+    optionTextProps,
   ) {
 		let titleNode = null
 		if (React.isValidElement(title)) {
 			titleNode = title
 		} else {
 			titleNode = (
-        <Text style={[btnStyle.title, optionStyle, {color: fontColor}]}>
+        <Text {...optionTextProps} style={[btnStyle.title, optionStyle, {color: fontColor}]}>
           {title}
         </Text>
       )
@@ -184,7 +185,8 @@ class ActionSheet extends Component {
       destructiveButtonIndex, optionButtonStyle,
       firstOptionButtonStyle,
       lastOptionButtonStyle,
-      optionStyle
+      optionStyle,
+      optionTextProps,
     } = this.props
     const firstOptionIdx = 0 === cancelButtonIndex ? 1: 0;
     const lastOptionIdx = options.length - 1 === cancelButtonIndex ?
@@ -197,7 +199,8 @@ class ActionSheet extends Component {
           optionButtonStyle,
           index === firstOptionIdx ? firstOptionButtonStyle : null,
           index === lastOptionIdx ? lastOptionButtonStyle : null,
-          optionStyle
+          optionStyle,
+          optionTextProps,
       )
 		})
 	}
@@ -269,6 +272,7 @@ ActionSheet.propTypes = {
   optionButtonHeight: PropTypes.number,
   cancelOptionMargin: PropTypes.number,
   titleHeight: PropTypes.number,
+  optionTextProps: PropTypes.any,
 }
 
 

--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -75,9 +75,10 @@ class ActionSheet extends Component {
 		let height = buttonHight * count + cancelMargin
 		if (props.title) height += titleHeight
     if (props.message) height += MESSAGE_H
-		if (height > MAX_HEIGHT) {
+    const maxHeight = props.height ? props.height * 0.7 : MAX_HEIGHT;
+		if (height > maxHeight) {
 			this.scrollEnabled = true;
-			return MAX_HEIGHT
+			return maxHeight
 		} else {
 			this.scrollEnabled = false;
 			return height


### PR DESCRIPTION
When the orientation is changed to landscape, height of the modal is not getting updated
 in the library. Therefore, passing the height prop to the action sheet.